### PR TITLE
sonos_exporter: add uptime, load

### DIFF
--- a/sonos_exporter
+++ b/sonos_exporter
@@ -42,11 +42,21 @@ class Collector(object):
             labels=["player", "device"])
         tx_packets = GaugeMetricFamily("sonos_tx_packets", "Transmitted packets",
             labels=["player", "device"])
+        uptime = GaugeMetricFamily("sonos_uptime_seconds", "System Uptime Seconds",
+            labels=["player"])
+        loadAvg1 = GaugeMetricFamily("sonos_load1", "1m load average",
+            labels=["player"])
+        loadAvg5 = GaugeMetricFamily("sonos_load5", "5m load average",
+            labels=["player"])
+        loadAvg15 = GaugeMetricFamily("sonos_load15", "15m load average",
+            labels=["player"])
 
         zones = soco.discover()
+        if zones is None:
+            return
         for zone in zones:
-            url = "http://%s:1400/status/ifconfig" % zone.ip_address
-            body = requests.get(url).text
+            interfaceUrl = "http://%s:1400/status/ifconfig" % zone.ip_address
+            body = requests.get(interfaceUrl).text
             ifconfig = get_ifconfig(body)
 
             for iface in parse_ifconfig(ifconfig):
@@ -57,14 +67,36 @@ class Collector(object):
                 rx_packets.add_metric([zone.player_name, device], value=float(iface.rxpkts))
                 tx_packets.add_metric([zone.player_name, device], value=float(iface.txpkts))
 
+            loadUrl = "http://%s:1400/status/uptime" % zone.ip_address
+            body = requests.get(loadUrl).text
+            load = get_load(body).replace(',', '').split()
+
+            loadAvg1.add_metric([zone.player_name], value=float(load[-3]))
+            loadAvg5.add_metric([zone.player_name], value=float(load[-2]))
+            loadAvg15.add_metric([zone.player_name], value=float(load[-1]))
+
+            zpUrl = "http://%s:1400/status/zp" % zone.ip_address
+            body = requests.get(zpUrl).text
+            ut = get_uptime(body)
+
+            uptime.add_metric([zone.player_name], value=int(ut['UptimeSeconds']))
+
         yield rx_bytes
         yield tx_bytes
         yield rx_packets
         yield tx_packets
+        yield loadAvg1
+        yield loadAvg5
+        yield loadAvg15
+        yield uptime
 
+def get_uptime(body):
+    tree = ElementTree.fromstring(body)
+    return dict((x.tag, x.text) for x in tree[0])
 
-Iface = namedtuple("Iface", "name rxbytes txbytes rxpkts txpkts")
-
+def get_load(body):
+    tree = ElementTree.fromstring(body)
+    return tree.find("Command[@cmdline='/usr/bin/uptime']").text.rstrip()
 
 def get_ifconfig(body):
     tree = ElementTree.fromstring(body)
@@ -76,11 +108,13 @@ def parse_ifconfig(text):
 
     blocks = text.strip().split("\n\n")
     for block in blocks:
-        ifaces.append(parse_block(block))
+        ifaces.append(parse_interface(block))
 
     return ifaces
 
-def parse_block(block):
+Iface = namedtuple("Iface", "name rxbytes txbytes rxpkts txpkts")
+
+def parse_interface(block):
     # This is not exactly general purpose, but I'm figuring the upstream
     # release cycle means the format won't change often.
     #


### PR DESCRIPTION
Hey @pteichman!

I was playing around with this on my network and figured I'd add a few more metrics. I'm not sure how amenable you are to these changes, but I wanted to at least commit them back upstream! It adds:

* System Uptime (in seconds)
* Linux Load Averages (1m, 5m, 15m)

There's probably some other metrics you can pull from the `/status/zp` route, which is why I mapped the whole page to a dictionary instead of just pulling the system uptime. This works on my (limited) network of two devices of a Play:1 and first-get Play:5, but I have no idea if it works across everything.

I also fixed a potential bug where the collector would crash if there were no devices on the network. 
